### PR TITLE
Partial refactor of `CaseExperiment` class

### DIFF
--- a/src/esnb/__init__.py
+++ b/src/esnb/__init__.py
@@ -1,7 +1,64 @@
+import logging
+import socket
+import sys
+import os
+
+logger = logging.getLogger(__name__)
+
+
+# ANSI color codes
+RESET = "\033[0m"
+COLORS = {
+    'DEBUG': "\033[36m",    # Cyan
+    'INFO': "\033[32m",     # Green
+    'WARNING': "\033[33m",  # Yellow
+    'ERROR': "\033[31m",    # Red
+    'CRITICAL': "\033[41m", # Red background
+}
+
+class ColorFormatter(logging.Formatter):
+    def format(self, record):
+        log_color = COLORS.get(record.levelname, RESET)
+        record.levelname = f"{log_color}{record.levelname}{RESET}"
+        record.msg = f"{log_color}{record.msg}{RESET}"
+        return super().format(record)
+
+# Create logger
+log_level = os.environ.get("ESNB_LOG_LEVEL","WARNING")
+if log_level == "DEBUG":
+    logger.setLevel(logging.DEBUG)
+elif log_level == "INFO":
+    logger.setLevel(logging.INFO)
+elif log_level == "WARNING":
+    logger.setLevel(logging.WARNING)
+elif log_level == "ERROR":
+    logger.setLevel(logging.ERROR)
+elif log_level == "CRITICAL":
+    logger.setLevel(logging.CRITICAL)
+else:
+    raise ValueError(f"Unrecognized logging level: {level}")
+
+logger.handlers = []  # Clear existing handlers
+    
+# StreamHandler to stdout
+handler = logging.StreamHandler(sys.stdout)
+#handler.setLevel(logging.WARNING)
+
+# Include module and line number in format string
+#format_str = '%(asctime)s - %(levelname)s - %(module)s:%(lineno)d - %(message)s'
+format_str = '%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s'
+formatter = ColorFormatter(format_str)
+
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
 from . import core
 
 from .core.RequestedVariable import RequestedVariable
 from .core.CaseExperiment import CaseExperiment
+from .core.CaseExperiment2 import CaseExperiment2
 from .core.NotebookDiagnostic import NotebookDiagnostic
 from .core.CaseGroup import CaseGroup
 from .core.esnb_datastore import esnb_datastore
+
+from . import sites

--- a/src/esnb/core/CaseExperiment2.py
+++ b/src/esnb/core/CaseExperiment2.py
@@ -1,0 +1,171 @@
+import intake
+import logging
+import os
+import json
+from pathlib import Path
+
+from esnb import sites
+from esnb.core.mdtf import MDTFCaseSettings
+from . import html
+
+
+logger = logging.getLogger(__name__)
+
+def infer_case_source(source):
+    """
+    Infer the source type from the input.
+    Args:
+        source (str, int, Path): The source input which can be a path to an intake_esm catalog,
+                                 MDTF settings file, or a DORA ID.
+    Returns:
+        str: The mode of the source, which can be "intake_path", "intake_url", "dora_id", or "dora_url"
+    """
+
+    if isinstance(source, str):
+        if source.isnumeric():
+            logger.debug(f"Found source string with numeric Dora ID - {source}")
+            mode = "dora_id"
+        elif source.startswith("http") or source.startswith("https"):
+            if "dora.gfdl" in source:
+                logger.debug(f"Found source url pointing to Dora - {source}")
+                mode = "dora_url"
+            else:
+                logger.debug(f"Found source url suggesting intake catalog - {source}")
+                mode = "intake_url"
+        elif "-" in source:
+            if source.split("-")[1].isnumeric():
+                logger.debug(f"Found source string with project-level dora ID - {source}")
+                mode = "dora_id"
+            else:
+                mode = "path"
+        else:
+            mode = "path"
+    elif isinstance(source, int):
+        logger.debug(f"Found source integer suggesting dora ID - {source}")
+        mode = "dora_id"
+    else:
+        raise ValueError("Unsupported source type. Must be path or url to"+
+                         " intake_esm catalog, MDTF settings file, or DORA ID")
+
+    if mode == "path":
+        logger.debug(f"Assuming source is a local file path - {source}")
+        filepath = Path(source)
+        if not filepath.exists():
+            logger.error(f"Path {filepath} does not exist")
+            raise FileNotFoundError(f"Path {filepath} does not exist")
+        if filepath.is_dir():
+            mode = "pp_dir"
+            logger.debug(f"Supplied path appears to be a directory, possibly containing post-processing")
+            err = f"The supplied path is a directory. In the future, support will be added to generate a catalog."
+            logger.error(err)
+            raise NotImplementedError(err)
+        else:
+            try:
+                with open(filepath, 'r') as f:
+                    json.load(f)
+                logger.debug(f"Source appears to be a JSON file, assuming intake catalog")
+                mode = "intake_path"
+            except json.JSONDecodeError:
+                logger.debug(f"Source is not a JSON file, assuming MDTF settings file")
+                mode = "mdtf_settings"
+
+    return mode            
+
+def open_intake_catalog(source,mode):
+    if mode == "intake_url":
+        logger.info(f"Fetching intake catalog from url: {source}")
+        catalog = intake.open_esm_datastore(source)
+
+    elif mode == "intake_path":
+        logger.info(f"Opening intake catalog from file: {source}")
+        catalog = intake.open_esm_datastore(source)
+
+    else:
+        err = f"Encountered unrecognized source mode: {mode}"
+        loggger.error(err) 
+        raise RuntimeError(err)
+     
+    return catalog
+
+def open_intake_catalog_dora(source,mode):
+    if mode == "dora_url":
+        url = source
+    elif mode == "dora_id":
+        url = f"https://{sites.gfdl.dora_hostname}/api/intake/{source}.json"
+    else:
+        err = f"Encountered unrecognized source mode: {mode}"
+        loggger.error(err) 
+        raise RuntimeError(err)
+    
+    logger.info(f"Fetching intake catalog from url: {url}")
+    if not sites.gfdl.dora:
+       logger.critical(f"Network route to dora is unavailble. Check connection.") 
+    catalog = intake.open_esm_datastore(url)
+
+    return catalog
+
+class CaseExperiment2(MDTFCaseSettings):
+    def __init__(self, source, verbose=True):
+        self.source = source
+        self.mode = infer_case_source(self.source)
+
+        # Read the MDTF settings case file
+        if self.mode == "mdtf_settings":
+            logger.info("Loading MDTF Settings File")
+            self.load_mdtf_settings_file(source)
+            if len(self.mdtf_settings["case_list"]) == 0:
+                raise ValueError("No cases found in MDTF settings file")
+            elif len(self.mdtf_settings["case_list"]) > 1:
+                raise ValueError("Multiple cases found in MDTF settings file. "+"Please initialize using the `CaseGroup` class.")
+            self.name = list(self.mdtf_settings["case_list"].keys())[0]
+
+            catalog_file = Path(self.catalog)
+            logger.debug(f"Loading intake catalog from path specified in MDTF settings file: {str(catalog_file)}")
+            if catalog_file.exists():
+                self.catalog = open_intake_catalog(str(catalog_file), "intake_path")
+            else:
+                logger.warning(f"MDTF-specified intake catalog path does not exist: {str(catalog_file)}")
+
+        elif "intake" in self.mode or "dora" in self.mode:
+            if "intake" in self.mode:
+                self.catalog = open_intake_catalog(self.source, self.mode)
+            elif "dora" in self.mode:
+                self.catalog = open_intake_catalog_dora(self.source, self.mode)
+            self.name = self.catalog.__dict__["esmcat"].__dict__["id"]
+
+        else:
+            err = f"Encountered unrecognized source mode: {mode}"
+            loggger.error(err) 
+            raise RuntimeError(err)
+
+    def _repr_html_(self):
+        result = html.gen_html_sub()
+        # Table Header
+        result += f"<h3>{self.__class__.__name__}  --  {self.name}</h3>"
+        result += "<table class='cool-class-table'>"
+
+        # Iterate over attributes, handling the dictionary separately
+        result += f"<tr><td><strong>Source Type</strong></td><td>{self.mode}</td></tr>"
+        result += f"<tr><td><strong>catalog</strong></td><td>{str(self.catalog).replace("<","").replace(">","")}</td></tr>"
+        #for key in sorted(self.__dict__.keys()):
+        #    value = str(self.__dict__[key])
+        #    if key == 'mdtf_settings':
+        #        continue
+        #    result += f"<tr><td><strong>{key}</strong></td><td>{value}</td></tr>"
+
+        if hasattr(self, "mdtf_settings"):
+            result += "<tr><td colspan='2'>"
+            result += "<details>"
+            result += "<summary>View MDTF Settings</summary>"
+            result += "<div><table>"
+            for d_key in sorted(self.mdtf_settings.keys()):
+                 d_value = self.mdtf_settings[d_key]
+                 result += f"<tr><td>{d_key}</td><td>{d_value}</td></tr>"
+            result += "</table></div>"
+            result += "</details>"
+            result += "</td></tr>"
+        
+        result += "</table>"
+
+        return result
+

--- a/src/esnb/core/__init__.py
+++ b/src/esnb/core/__init__.py
@@ -19,10 +19,12 @@ except:
 
 from . import RequestedVariable
 from . import CaseExperiment
+from . import CaseExperiment2
 from . import NotebookDiagnostic
 from . import CaseGroup
 from . import esnb_datastore
 from . import util
+from . import mdtf
 
 
 class NoAliasDumper(yaml.SafeDumper):

--- a/src/esnb/core/html.py
+++ b/src/esnb/core/html.py
@@ -1,0 +1,34 @@
+def gen_html_sub():
+    html = """
+        <style>
+            .cool-class-table {{
+                border-collapse: collapse;
+                width: 400px;
+                font-family: sans-serif;
+                text-align: left;
+            }}
+            .cool-class-table th, .cool-class-table td {{
+                border: 1px solid #ddd;
+                padding: 8px;
+                text-align: left !important;
+            }}
+            .cool-class-table tr:nth-child(even) {{
+                background-color: #f2f2f2; /* Lighter Gray */
+                text-align: left;
+            }}
+            .cool-class-table tr:nth-child(odd) {{
+                background-color: #ffffff; /* White */
+                text-align: left;
+            }}
+            .cool-class-table summary {{
+                cursor: pointer;
+                font-weight: bold;
+            }}
+            .cool-class-table details > div {{
+                padding: 10px;
+                border-top: 1px solid #ccc;
+                margin-top: 5px;
+            }}
+        </style>
+        """
+    return html

--- a/src/esnb/core/mdtf.py
+++ b/src/esnb/core/mdtf.py
@@ -1,0 +1,94 @@
+""" Module with MDTF bindings """
+
+import logging
+from pathlib import Path
+from esnb.core.util import missing_dict_keys
+import yaml
+
+logger = logging.getLogger(__name__)
+
+def gen_mdtf_settings_file_stub():
+    return {
+        "pod_list": [],
+        "case_list": {
+            "casename": {
+                "model": None,
+                "convention": None,
+                "startdate": "YYYYMMDD000000",
+                "enddate": "YYYYMMDD000000",
+            }
+        },
+        "DATA_CATALOG": None,
+        "OBS_DATA_ROOT": None,
+        "WORK_DIR": None,
+        "OUTPUT_DIR": None,
+        "conda_root": None,
+        "conda_env_root": None,
+        "micromamba_exe": None,
+        "large_file": None,
+        "save_ps": None,
+        "save_pp_data": None,
+        "translate_data": None,
+        "make_variab_tar": None,
+        "overwrite": None,
+        "make_multicase_figure_html": None,
+        "run_pp": None,
+        "user_pp_scripts": None,
+    }
+
+def standardize_mdtf_case_settings(settings):
+    target = gen_mdtf_settings_file_stub()
+    for k in target.keys():
+            if k in settings.keys():
+                target[k] = settings[k]
+    return target
+
+class MDTFCaseSettings:
+    """
+    Class to handle MDTF case settings and metadata.
+    This class is designed to load and manage MDTF settings files, which
+    contain metadata about cases, data catalogs, and other relevant information.
+    """
+    def load_mdtf_settings_file(self, settings_file):
+        """
+        Load MDTF settings from a YAML file.
+
+        Parameters
+        ----------
+        settings_file : str or Path
+            Path to the MDTF settings YAML file.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the settings file does not exist.
+        ValueError
+            If required keys are missing in the settings file.
+        """
+        settings_file = Path(settings_file)
+        if not settings_file.exists():
+            raise FileNotFoundError(f"MDTF settings file does not exist: {settings_file}")
+        self.source = str(settings_file)
+
+        with open(settings_file, "r") as f:
+            _settings = yaml.safe_load(f)
+
+        missing_keys = missing_dict_keys(_settings, ["DATA_CATALOG", "case_list"])
+        if len(missing_keys) > 0:
+            raise ValueError(
+                f"Encountered missing fields {missing_keys} in MDTF settings file {self.source}"
+            )
+
+        # set special attribute
+        self.catalog = _settings["DATA_CATALOG"]
+        self.mdtf_settings = _settings
+
+        assert (
+            len(self.catalog) > 0
+        ), f"`DATA_CATALOG` is empty in MDTF settings file {self.source}"
+
+    def write_mdtf_settings_file(self, filename="case_settings.yml", fmt="yaml"):
+        _settings = getattr(self, "mdtf_settings", None)
+        _settings = gen_mdtf_settings_file_stub() if _settings is None else _settings
+        _settings = standardize_mdtf_case_settings(_settings)
+        write_dict(_settings,filename,fmt)

--- a/src/esnb/core/util.py
+++ b/src/esnb/core/util.py
@@ -19,6 +19,26 @@ except:
 
 from . import esnb_datastore
 
+def write_dict(dictobj, filename, fmt="yaml"):
+    if fmt == "yaml":
+        output = yaml.dump(dictobj, sort_keys=True, indent=2)
+    elif fmt == "json":
+        output = json.dumps(dictobj, indent=4)
+    else:
+        raise ValueError(f"`write_dict` unable to write to unrecognized format: {fmt}")
+
+    if filename is None:
+        print(output)
+    else:
+        with open(filename, "w") as file:
+            file.write(output)
+
+def missing_dict_keys(dictobj, expected_keys):
+    missing = []
+    for key in expected_keys:
+        if key not in dictobj.keys():
+            missing.append(key)
+    return missing
 
 def consolidate_datasets(dset_dict):
     all_dsets = [v for _, v in dset_dict.items()]

--- a/src/esnb/sites/__init__.py
+++ b/src/esnb/sites/__init__.py
@@ -1,0 +1,1 @@
+from . import gfdl

--- a/src/esnb/sites/gfdl.py
+++ b/src/esnb/sites/gfdl.py
@@ -10,6 +10,7 @@ import json
 import pandas as pd
 import xarray as xr
 import yaml
+import socket
 
 try:
     import doralite
@@ -17,8 +18,21 @@ try:
 except:
     pass
 
+import logging
+logger = logging.getLogger(__name__)
+
 from esnb.core.esnb_datastore import esnb_datastore
 
+
+def is_host_reachable(host, port=80, timeout=1):
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except (socket.timeout, socket.error):
+        return False
+
+dora_hostname = os.environ.get("ESNB_GFDL_DORA_HOSTNAME","dora.gfdl.noaa.gov")
+dora = is_host_reachable(dora_hostname, port=443)
 
 def call_dmget(files, status=False, verbose=True):
     files = [files] if not isinstance(files, list) else files

--- a/tests/test_CaseExperiment.py
+++ b/tests/test_CaseExperiment.py
@@ -1,0 +1,40 @@
+import pytest
+import intake_esm
+
+from esnb.core.CaseExperiment2 import CaseExperiment2, open_intake_catalog, open_intake_catalog_dora
+
+dora_url = "https://dora.gfdl.noaa.gov/api/intake/odiv-1.json"
+dora_id = "odiv-1"
+dora_id_2 = 895
+intake_url = "https://storage.googleapis.com/cmip6/pangeo-cmip6.json"
+mdtf_settings = "/home/jpk/pkgs/notebook-template/tests/test_data/input_timeslice_test.yml"
+intake_path = "/home/jpk/pkgs/notebook-template/tests/test_data/intake-uda-cmip.json"
+
+def test_infer_case_source():
+    assert CaseExperiment2(dora_url).mode == "dora_url"
+    assert CaseExperiment2(dora_id).mode == "dora_id"
+    assert CaseExperiment2(dora_id_2).mode == "dora_id"
+    assert CaseExperiment2(intake_url).mode == "intake_url"
+    assert CaseExperiment2(mdtf_settings).mode == "mdtf_settings"
+    assert CaseExperiment2(intake_path).mode == "intake_path"
+
+def test_open_intake_from_path():
+    result = open_intake_catalog(intake_path,"intake_path")
+    assert isinstance(result, intake_esm.core.esm_datastore)
+
+def test_open_intake_from_url():
+    result = open_intake_catalog(intake_url,"intake_url")
+    assert isinstance(result, intake_esm.core.esm_datastore)
+
+def test_open_intake_from_dora_id_1():
+    result = open_intake_catalog_dora(dora_id,"dora_id")
+    assert isinstance(result, intake_esm.core.esm_datastore)
+
+def test_open_intake_from_dora_id_2():
+    result = open_intake_catalog_dora(dora_id_2,"dora_id")
+    assert isinstance(result, intake_esm.core.esm_datastore)
+
+def test_open_intake_from_dora_url():
+    result = open_intake_catalog_dora(dora_url,"dora_url")
+    assert isinstance(result, intake_esm.core.esm_datastore)
+

--- a/tests/test_data/intake-uda-cmip.json
+++ b/tests/test_data/intake-uda-cmip.json
@@ -1,0 +1,138 @@
+{
+  "esmcat_version": "0.0.1",
+  "attributes": [
+    {
+      "column_name": "activity_id",
+      "vocabulary": "",
+      "required": false
+    },
+    {
+      "column_name": "institution_id",
+      "vocabulary": "",
+      "required": false
+    },
+    {
+      "column_name": "source_id",
+      "vocabulary": "",
+      "required": false
+    },
+    {
+      "column_name": "experiment_id",
+      "vocabulary": "",
+      "required": true
+    },
+    {
+      "column_name": "frequency",
+      "vocabulary": "https://raw.githubusercontent.com/NOAA-GFDL/CMIP6_CVs/master/CMIP6_frequency.json",
+      "required": true
+    },
+    {
+      "column_name": "realm",
+      "vocabulary": "",
+      "required": true
+    },
+    {
+      "column_name": "table_id",
+      "vocabulary": "",
+      "required": false
+    },
+    {
+      "column_name": "member_id",
+      "vocabulary": "",
+      "required": false
+    },
+    {
+      "column_name": "grid_label",
+      "vocabulary": "",
+      "required": false
+    },
+    {
+      "column_name": "variable_id",
+      "vocabulary": "",
+      "required": true
+    },
+    {
+      "column_name": "time_range",
+      "vocabulary": "",
+      "required": true
+    },
+    {
+      "column_name": "chunk_freq",
+      "required": false
+    },
+    {
+      "column_name": "platform",
+      "vocabulary": "",
+      "required": false
+    },
+    {
+      "column_name": "target",
+      "vocabulary": "",
+      "required": false
+    },
+    {
+      "column_name": "cell_methods",
+      "vocabulary": "",
+      "required": "enhanced"
+    },
+    {
+      "column_name": "path",
+      "vocabulary": "",
+      "required": true
+    },
+    {
+      "column_name": "dimensions",
+      "vocabulary": "",
+      "required": "enhanced"
+    },
+    {
+      "column_name": "version_id",
+      "vocabulary": "",
+      "required": false
+    },
+    {
+      "column_name": "standard_name",
+      "vocabulary": "",
+      "required": "enhanced"
+    }
+  ],
+  "assets": {
+    "column_name": "path",
+    "format": "netcdf",
+    "format_column_name": null
+  },
+  "aggregation_control": {
+    "variable_column_name": "variable_id",
+    "groupby_attrs": [
+      "source_id",
+      "experiment_id",
+      "frequency",
+      "table_id",
+      "grid_label",
+      "realm",
+      "member_id",
+      "chunk_freq"
+    ],
+    "aggregations": [
+      {
+        "type": "union",
+        "attribute_name": "variable_id",
+        "options": {}
+      },
+      {
+        "type": "join_existing",
+        "attribute_name": "time_range",
+        "options": {
+          "dim": "time",
+          "coords": "minimal",
+          "compat": "override"
+        }
+      }
+    ]
+  },
+  "id": "esm_catalog_ESM4",
+  "description": null,
+  "title": null,
+  "last_updated": "2023-05-07T16:35:52Z",
+  "catalog_file": "intake-uda-cmip.csv.gz"
+}

--- a/tests/test_mdtf.py
+++ b/tests/test_mdtf.py
@@ -1,0 +1,12 @@
+import pytest
+from esnb.core import mdtf
+
+def test_MDTFCaseSettings():
+    settings_file = "/home/John.Krasting/pkgs/notebook-template/tests/test_data/input_timeslice_test.yml"
+    settings = mdtf.MDTFCaseSettings
+    settings.load_mdtf_settings_file(settings, settings_file)
+
+def test_MDTFCaseSettings_invalid_file():
+    with pytest.raises(FileNotFoundError):
+        x = mdtf.MDTFCaseSettings
+        x = x.load_mdtf_settings_file(x, "non_existent_file.yml")


### PR DESCRIPTION
* Added a `CaseExperiment2` class that is capable of initializing from an MDTF settings file, file or URL-based intake catalog, or Dora ID
* Added hook for future catalog generation
* Enabled Python logging module
* Added `_html_repr_` functionality